### PR TITLE
Clean up duplicateBuilding validator

### DIFF
--- a/validators/duplicateBuilding/README.md
+++ b/validators/duplicateBuilding/README.md
@@ -1,6 +1,6 @@
 #### Description
 
-This validator detects all the buildings that have more than 90% of their area in overlap to another building.
+This validator detects all the buildings that have more than 90% of their area in overlap to another building. The callback returns the total number of duplicate buildings.
 
 #### Usage
 

--- a/validators/duplicateBuilding/index.js
+++ b/validators/duplicateBuilding/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var duplicateCount = 0;
 
 module.exports = function(opts, mbtilesPath, callback) {
   tileReduce({
@@ -15,8 +16,10 @@ module.exports = function(opts, mbtilesPath, callback) {
       }
     ]
   })
-    .on('reduce', function() {})
+    .on('reduce', function(count) {
+      duplicateCount = duplicateCount + count;
+    })
     .on('end', function() {
-      callback && callback();
+      callback && callback(null, duplicateCount);
     });
 };

--- a/validators/duplicateBuilding/map.js
+++ b/validators/duplicateBuilding/map.js
@@ -8,6 +8,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
   var buildings = {};
   var bboxes = [];
   var output = {};
+  var duplicateCount = 0;
   var osmlint = 'duplicatebuildings';
   for (var i = 0; i < layer.features.length; i++) {
     var val = layer.features[i];
@@ -34,17 +35,10 @@ module.exports = function(tileLayers, tile, writeData, done) {
         );
         //detecting buildings that have > 90% overlap
         if (difference && (areabuildingA - turf.area(difference)) > (areabuildingA * 0.9)) {
-          var points = turf.explode(buildingA);
-          var multiPoint = turf.combine(points).features[0];
-          multiPoint.properties = {
-            _fromWay: buildingA.properties['@id'],
-            _toWay: buildingB.properties['@id'],
-            _osmlint: osmlint
-          };
+          duplicateCount = duplicateCount + 1;
           //save detection
           output[overlap.id] = buildingA;
           output[bbox.id] = buildingB;
-          output[overlap.id + bbox.id + 'M'] = multiPoint;
         }
       }
     }
@@ -55,7 +49,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
     var fc = turf.featureCollection(result);
     writeData(JSON.stringify(fc) + '\n');
   }
-  done(null, null);
+  done(null, duplicateCount / 2);
 };
 
 function objBbox(obj, id) {


### PR DESCRIPTION
don't create point cloud. return count of buildings. cleaner output:

![image](https://user-images.githubusercontent.com/371666/38361820-52541c42-38ec-11e8-840e-0c077aca1c46.png)
